### PR TITLE
feat: adds "prepare" script step to allow building from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "access": "public"
   },
   "scripts": {
+    "prepare": "make build",
     "build": "make build",
     "i18n_extract": "fedx-scripts formatjs extract",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",


### PR DESCRIPTION
Since `npm v5.0.0` ([ref](https://blog.npmjs.org/post/161081169345/v500)):

> git dependencies with `prepare` scripts will have their `devDependencies` installed, and `npm install` run in their directory before being packed.

Adding a `prepare` script to this repo lets us reference unmerged branches when working on dependency upgrades in frontend-apps, e.g. https://github.com/openedx/frontend-app-course-authoring/pull/1052/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48